### PR TITLE
feat(claude-logs): add Claude Code JSONL log parsing for usage analysis

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -10,6 +10,7 @@
 		"typecheck": "bunx tsc --noEmit"
 	},
 	"dependencies": {
+		"@better-ccflare/claude-logs": "workspace:*",
 		"@better-ccflare/core": "workspace:*",
 		"@better-ccflare/core-di": "workspace:*",
 		"@better-ccflare/database": "workspace:*",

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "ccflare",
@@ -18,6 +19,7 @@
       "name": "@better-ccflare/server",
       "version": "0.1.0",
       "dependencies": {
+        "@better-ccflare/claude-logs": "workspace:*",
         "@better-ccflare/config": "workspace:*",
         "@better-ccflare/core": "workspace:*",
         "@better-ccflare/core-di": "workspace:*",
@@ -32,7 +34,7 @@
     },
     "apps/tui": {
       "name": "better-ccflare",
-      "version": "1.2.28",
+      "version": "1.2.39",
       "bin": {
         "better-ccflare": "dist/better-ccflare",
       },
@@ -58,6 +60,14 @@
       "devDependencies": {
         "@types/node": "^22.5.4",
         "typescript": "^5.7.2",
+      },
+    },
+    "packages/claude-logs": {
+      "name": "@better-ccflare/claude-logs",
+      "version": "0.1.0",
+      "dependencies": {
+        "@better-ccflare/logger": "workspace:*",
+        "@better-ccflare/types": "workspace:*",
       },
     },
     "packages/cli-commands": {
@@ -157,6 +167,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@better-ccflare/agents": "workspace:*",
+        "@better-ccflare/claude-logs": "workspace:*",
         "@better-ccflare/config": "workspace:*",
         "@better-ccflare/core": "workspace:*",
         "@better-ccflare/database": "workspace:*",
@@ -274,6 +285,8 @@
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.1.3", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw=="],
 
     "@better-ccflare/agents": ["@better-ccflare/agents@workspace:packages/agents"],
+
+    "@better-ccflare/claude-logs": ["@better-ccflare/claude-logs@workspace:packages/claude-logs"],
 
     "@better-ccflare/cli-commands": ["@better-ccflare/cli-commands@workspace:packages/cli-commands"],
 
@@ -675,7 +688,7 @@
 
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
-    "@better-ccflare/dashboard-web/@types/bun": ["@types/bun@1.3.0", "", { "dependencies": { "bun-types": "1.3.0" } }, "sha512-+lAGCYjXjip2qY375xX/scJeVRmZ5cY0wyHYyCYxNcdEXrQ4AOe3gACgd4iQ8ksOslJtW4VNxBJ8llUwc3a6AA=="],
+    "@better-ccflare/dashboard-web/@types/bun": ["@types/bun@1.3.4", "", { "dependencies": { "bun-types": "1.3.4" } }, "sha512-EEPTKXHP+zKGPkhRLv+HI0UEX8/o+65hqARxLy8Ov5rIxMBPNTjeZww00CIihrIQGEQBYg+0roO5qOnS/7boGA=="],
 
     "@better-ccflare/errors/@types/bun": ["@types/bun@1.1.15", "", { "dependencies": { "bun-types": "1.1.42" } }, "sha512-Fi7ND1jCq8O5iU3s9z3TKHggD0hidgpe7wSxyisviXpbMmY4B1KiokF3f/mmjOoDrEcf873tSpixgen7Wm9X0g=="],
 
@@ -697,7 +710,7 @@
 
     "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.0.0", "", { "dependencies": { "get-east-asian-width": "^1.0.0" } }, "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA=="],
 
-    "@better-ccflare/dashboard-web/@types/bun/bun-types": ["bun-types@1.3.0", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-u8X0thhx+yJ0KmkxuEo9HAtdfgCBaM/aI9K90VQcQioAmkVp3SG3FkwWGibUFz3WdXAdcsqOcbU40lK7tbHdkQ=="],
+    "@better-ccflare/dashboard-web/@types/bun/bun-types": ["bun-types@1.3.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-5ua817+BZPZOlNaRgGBpZJOSAQ9RQ17pkwPD0yR7CfJg+r8DgIILByFifDTa+IPDDxzf5VNhtNlcKqFzDgJvlQ=="],
 
     "@better-ccflare/errors/@types/bun/bun-types": ["bun-types@1.1.42", "", { "dependencies": { "@types/node": "~20.12.8", "@types/ws": "~8.5.10" } }, "sha512-beMbnFqWbbBQHll/bn3phSwmoOQmnX2nt8NI9iOQKFbgR5Z6rlH3YuaMdlid8vp5XGct3/W4QVQBmhoOEoe4nw=="],
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,11 +10,20 @@ services:
       - better-ccflare-data:/data
       # Optional: mount custom config
       # - ./config:/app/config:ro
+      # Optional: mount Claude Code logs for usage analysis (read-only)
+      # Uncomment to enable historical usage tracking from local Claude Code sessions
+      # - ${HOME}/.claude:/host-claude:ro
+      # - ${HOME}/.config/claude:/host-config-claude:ro
     environment:
       - NODE_ENV=production
       - BETTER_CCFLARE_DB_PATH=/data/better-ccflare.db
       # Optional: configure logging
       # - LOG_LEVEL=info
+      # Optional: Claude logs configuration (uncomment if mounting Claude logs volumes)
+      # - CLAUDE_CONFIG_DIR=/host-claude,/host-config-claude
+      # - CLAUDE_LOGS_ENABLED=true
+      # - CLAUDE_LOGS_WATCH=true
+      # - CLAUDE_LOGS_SCAN_ON_STARTUP=true
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
       interval: 30s

--- a/packages/claude-logs/package.json
+++ b/packages/claude-logs/package.json
@@ -1,0 +1,16 @@
+{
+	"name": "@better-ccflare/claude-logs",
+	"version": "0.1.0",
+	"type": "module",
+	"main": "./src/index.ts",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"typecheck": "bunx tsc --noEmit"
+	},
+	"dependencies": {
+		"@better-ccflare/types": "workspace:*",
+		"@better-ccflare/logger": "workspace:*"
+	}
+}

--- a/packages/claude-logs/src/index.ts
+++ b/packages/claude-logs/src/index.ts
@@ -1,0 +1,38 @@
+// Main service
+export { ClaudeLogsService, type ClaudeLogsRepository } from "./service";
+
+// Watcher
+export { ClaudeLogWatcher } from "./watcher";
+
+// Scanner
+export {
+	scanAllJSONLFiles,
+	scanModifiedFiles,
+	getFileMetadata,
+} from "./scanner";
+
+// Parser
+export {
+	parseLine,
+	parseJSONLContent,
+	parseJSONLContentFromLine,
+} from "./parser";
+
+// Paths
+export {
+	getClaudeConfigDirs,
+	getProjectsDir,
+	extractProjectPath,
+} from "./paths";
+
+// Types
+export type {
+	RawLogEntry,
+	ParsedLogEntry,
+	ProcessedFile,
+	ScanResult,
+	ScanError,
+	ClaudeLogsServiceOptions,
+	FileWatchEvent,
+	FileWatchEventData,
+} from "./types";

--- a/packages/claude-logs/src/parser.ts
+++ b/packages/claude-logs/src/parser.ts
@@ -1,0 +1,180 @@
+import type { ParsedLogEntry, RawLogEntry, ScanError } from "./types";
+
+/**
+ * Parse a single JSONL line into a log entry
+ *
+ * @param line - A single line from a JSONL file
+ * @param filePath - Path to the source file
+ * @param projectPath - Extracted project path
+ * @param fileModifiedAt - File modification timestamp
+ * @param lineNumber - Line number for error reporting
+ * @returns ParsedLogEntry or null if line is invalid/empty
+ */
+export function parseLine(
+	line: string,
+	filePath: string,
+	projectPath: string,
+	fileModifiedAt: number,
+	lineNumber?: number,
+): { entry: ParsedLogEntry | null; error: ScanError | null } {
+	const trimmed = line.trim();
+
+	// Skip empty lines
+	if (!trimmed) {
+		return { entry: null, error: null };
+	}
+
+	try {
+		const raw = JSON.parse(trimmed) as RawLogEntry;
+
+		// Validate required fields
+		if (!raw.uuid || !raw.sessionId || !raw.timestamp) {
+			return {
+				entry: null,
+				error: {
+					filePath,
+					line: lineNumber,
+					error: "Missing required fields (uuid, sessionId, or timestamp)",
+				},
+			};
+		}
+
+		// Parse timestamp
+		const timestamp = new Date(raw.timestamp).getTime();
+		if (Number.isNaN(timestamp)) {
+			return {
+				entry: null,
+				error: {
+					filePath,
+					line: lineNumber,
+					error: `Invalid timestamp: ${raw.timestamp}`,
+				},
+			};
+		}
+
+		// Extract usage data
+		const usage = raw.message?.usage || {};
+		const inputTokens = usage.input_tokens || 0;
+		const outputTokens = usage.output_tokens || 0;
+		const cacheCreationInputTokens = usage.cache_creation_input_tokens || 0;
+		const cacheReadInputTokens = usage.cache_read_input_tokens || 0;
+		const totalTokens =
+			inputTokens +
+			outputTokens +
+			cacheCreationInputTokens +
+			cacheReadInputTokens;
+
+		const entry: ParsedLogEntry = {
+			uuid: raw.uuid,
+			sessionId: raw.sessionId,
+			projectPath,
+			timestamp,
+			role: raw.message?.role || "unknown",
+			model: raw.message?.model || null,
+			inputTokens,
+			outputTokens,
+			cacheCreationInputTokens,
+			cacheReadInputTokens,
+			totalTokens,
+			costUsd: raw.costUSD || 0,
+			gitBranch: raw.gitBranch || null,
+			cwd: raw.cwd || null,
+			filePath,
+			fileModifiedAt,
+		};
+
+		return { entry, error: null };
+	} catch (err) {
+		return {
+			entry: null,
+			error: {
+				filePath,
+				line: lineNumber,
+				error: `JSON parse error: ${err instanceof Error ? err.message : String(err)}`,
+			},
+		};
+	}
+}
+
+/**
+ * Parse entire JSONL file content
+ *
+ * @param content - Full file content
+ * @param filePath - Path to the source file
+ * @param projectPath - Extracted project path
+ * @param fileModifiedAt - File modification timestamp
+ * @returns Array of parsed entries and any errors
+ */
+export function parseJSONLContent(
+	content: string,
+	filePath: string,
+	projectPath: string,
+	fileModifiedAt: number,
+): { entries: ParsedLogEntry[]; errors: ScanError[] } {
+	const entries: ParsedLogEntry[] = [];
+	const errors: ScanError[] = [];
+
+	const lines = content.split("\n");
+
+	for (let i = 0; i < lines.length; i++) {
+		const { entry, error } = parseLine(
+			lines[i],
+			filePath,
+			projectPath,
+			fileModifiedAt,
+			i + 1,
+		);
+
+		if (entry) {
+			entries.push(entry);
+		}
+		if (error) {
+			errors.push(error);
+		}
+	}
+
+	return { entries, errors };
+}
+
+/**
+ * Parse JSONL content starting from a specific line (for incremental updates)
+ *
+ * @param content - Full file content
+ * @param filePath - Path to the source file
+ * @param projectPath - Extracted project path
+ * @param fileModifiedAt - File modification timestamp
+ * @param startLine - Line number to start from (0-indexed)
+ * @returns Array of parsed entries and any errors
+ */
+export function parseJSONLContentFromLine(
+	content: string,
+	filePath: string,
+	projectPath: string,
+	fileModifiedAt: number,
+	startLine: number,
+): { entries: ParsedLogEntry[]; errors: ScanError[]; lineCount: number } {
+	const entries: ParsedLogEntry[] = [];
+	const errors: ScanError[] = [];
+
+	const lines = content.split("\n");
+	const lineCount = lines.length;
+
+	for (let i = startLine; i < lines.length; i++) {
+		const { entry, error } = parseLine(
+			lines[i],
+			filePath,
+			projectPath,
+			fileModifiedAt,
+			i + 1,
+		);
+
+		if (entry) {
+			entries.push(entry);
+		}
+		if (error) {
+			errors.push(error);
+		}
+	}
+
+	return { entries, errors, lineCount };
+}

--- a/packages/claude-logs/src/paths.ts
+++ b/packages/claude-logs/src/paths.ts
@@ -1,0 +1,80 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { existsSync } from "node:fs";
+
+/**
+ * Get Claude config directories to scan for log files
+ *
+ * Priority:
+ * 1. CLAUDE_CONFIG_DIR env var (comma-separated for multiple paths)
+ * 2. ~/.claude (legacy path)
+ * 3. ~/.config/claude (XDG-compliant path)
+ *
+ * @returns Array of existing config directory paths
+ */
+export function getClaudeConfigDirs(): string[] {
+	const dirs: string[] = [];
+
+	// 1. Check env var first (supports comma-separated paths for Docker mounts)
+	const envDirs = process.env.CLAUDE_CONFIG_DIR;
+	if (envDirs) {
+		const paths = envDirs.split(",").map((p) => p.trim());
+		for (const p of paths) {
+			if (p && existsSync(p)) {
+				dirs.push(p);
+			}
+		}
+	}
+
+	// 2. Check legacy path (~/.claude)
+	const legacyPath = join(homedir(), ".claude");
+	if (existsSync(legacyPath) && !dirs.includes(legacyPath)) {
+		dirs.push(legacyPath);
+	}
+
+	// 3. Check XDG path (~/.config/claude)
+	const xdgPath = join(homedir(), ".config", "claude");
+	if (existsSync(xdgPath) && !dirs.includes(xdgPath)) {
+		dirs.push(xdgPath);
+	}
+
+	return dirs;
+}
+
+/**
+ * Get the projects subdirectory for a config dir
+ * @param configDir - The base config directory
+ * @returns Path to the projects directory
+ */
+export function getProjectsDir(configDir: string): string {
+	return join(configDir, "projects");
+}
+
+/**
+ * Extract project path from a JSONL file path
+ *
+ * Given: /home/user/.claude/projects/my-project/session-123.jsonl
+ * Returns: my-project
+ *
+ * @param filePath - Full path to the JSONL file
+ * @param configDirs - List of config directories to check against
+ * @returns The project name/path or "unknown" if not determinable
+ */
+export function extractProjectPath(
+	filePath: string,
+	configDirs: string[],
+): string {
+	for (const configDir of configDirs) {
+		const projectsDir = getProjectsDir(configDir);
+		if (filePath.startsWith(projectsDir)) {
+			// Remove the projects dir prefix and split
+			const relativePath = filePath.substring(projectsDir.length + 1);
+			const parts = relativePath.split("/");
+			// The project path is everything except the last part (filename)
+			if (parts.length > 1) {
+				return parts.slice(0, -1).join("/");
+			}
+		}
+	}
+	return "unknown";
+}

--- a/packages/claude-logs/src/scanner.ts
+++ b/packages/claude-logs/src/scanner.ts
@@ -1,0 +1,234 @@
+import { readdir, stat, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { Logger } from "@better-ccflare/logger";
+import { getClaudeConfigDirs, getProjectsDir, extractProjectPath } from "./paths";
+import { parseJSONLContent, parseJSONLContentFromLine } from "./parser";
+import type { ParsedLogEntry, ProcessedFile, ScanError, ScanResult } from "./types";
+
+const log = new Logger("ClaudeLogScanner");
+
+/**
+ * Recursively find all .jsonl files in a directory
+ */
+async function findJSONLFiles(dir: string): Promise<string[]> {
+	const files: string[] = [];
+
+	try {
+		const entries = await readdir(dir, { withFileTypes: true });
+
+		for (const entry of entries) {
+			const fullPath = join(dir, entry.name);
+
+			if (entry.isDirectory()) {
+				// Recursively scan subdirectories
+				const subFiles = await findJSONLFiles(fullPath);
+				files.push(...subFiles);
+			} else if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+				files.push(fullPath);
+			}
+		}
+	} catch (err) {
+		// Directory might not exist or be inaccessible
+		log.debug(`Could not read directory ${dir}: ${err}`);
+	}
+
+	return files;
+}
+
+/**
+ * Scan all Claude config directories for JSONL files
+ *
+ * @returns ScanResult with all parsed entries
+ */
+export async function scanAllJSONLFiles(): Promise<ScanResult> {
+	const configDirs = getClaudeConfigDirs();
+	const entries: ParsedLogEntry[] = [];
+	const errors: ScanError[] = [];
+	let filesProcessed = 0;
+	let filesSkipped = 0;
+
+	if (configDirs.length === 0) {
+		log.warn("No Claude config directories found");
+		return {
+			entries: [],
+			filesProcessed: 0,
+			filesSkipped: 0,
+			entriesFound: 0,
+			errors: [],
+			configDirsUsed: [],
+		};
+	}
+
+	log.info(`Scanning ${configDirs.length} config directories: ${configDirs.join(", ")}`);
+
+	for (const configDir of configDirs) {
+		const projectsDir = getProjectsDir(configDir);
+
+		try {
+			const jsonlFiles = await findJSONLFiles(projectsDir);
+			log.info(`Found ${jsonlFiles.length} JSONL files in ${projectsDir}`);
+
+			for (const filePath of jsonlFiles) {
+				try {
+					const fileStat = await stat(filePath);
+					const content = await readFile(filePath, "utf-8");
+					const projectPath = extractProjectPath(filePath, configDirs);
+
+					const result = parseJSONLContent(
+						content,
+						filePath,
+						projectPath,
+						fileStat.mtimeMs,
+					);
+
+					entries.push(...result.entries);
+					errors.push(...result.errors);
+					filesProcessed++;
+
+					if (result.entries.length > 0) {
+						log.debug(
+							`Parsed ${result.entries.length} entries from ${filePath}`,
+						);
+					}
+				} catch (err) {
+					errors.push({
+						filePath,
+						error: `Failed to read file: ${err instanceof Error ? err.message : String(err)}`,
+					});
+					filesSkipped++;
+				}
+			}
+		} catch (err) {
+			log.warn(`Could not scan ${projectsDir}: ${err}`);
+		}
+	}
+
+	log.info(
+		`Scan complete: ${filesProcessed} files processed, ${entries.length} entries found, ${errors.length} errors`,
+	);
+
+	return {
+		entries,
+		filesProcessed,
+		filesSkipped,
+		entriesFound: entries.length,
+		errors,
+		configDirsUsed: configDirs,
+	};
+}
+
+/**
+ * Scan only modified files since last processing
+ *
+ * @param processedFiles - Map of file path to ProcessedFile metadata
+ * @returns ScanResult with only new/modified entries
+ */
+export async function scanModifiedFiles(
+	processedFiles: Map<string, ProcessedFile>,
+): Promise<ScanResult> {
+	const configDirs = getClaudeConfigDirs();
+	const entries: ParsedLogEntry[] = [];
+	const errors: ScanError[] = [];
+	let filesProcessed = 0;
+	let filesSkipped = 0;
+
+	if (configDirs.length === 0) {
+		return {
+			entries: [],
+			filesProcessed: 0,
+			filesSkipped: 0,
+			entriesFound: 0,
+			errors: [],
+			configDirsUsed: [],
+		};
+	}
+
+	for (const configDir of configDirs) {
+		const projectsDir = getProjectsDir(configDir);
+
+		try {
+			const jsonlFiles = await findJSONLFiles(projectsDir);
+
+			for (const filePath of jsonlFiles) {
+				try {
+					const fileStat = await stat(filePath);
+					const processed = processedFiles.get(filePath);
+
+					// Skip if file hasn't changed
+					if (
+						processed &&
+						processed.lastModifiedAt >= fileStat.mtimeMs &&
+						processed.lastSize === fileStat.size
+					) {
+						filesSkipped++;
+						continue;
+					}
+
+					const content = await readFile(filePath, "utf-8");
+					const projectPath = extractProjectPath(filePath, configDirs);
+
+					// If we have processed this file before, only parse new lines
+					if (processed && processed.lastLineCount > 0) {
+						const result = parseJSONLContentFromLine(
+							content,
+							filePath,
+							projectPath,
+							fileStat.mtimeMs,
+							processed.lastLineCount,
+						);
+
+						entries.push(...result.entries);
+						errors.push(...result.errors);
+					} else {
+						// Full parse for new files
+						const result = parseJSONLContent(
+							content,
+							filePath,
+							projectPath,
+							fileStat.mtimeMs,
+						);
+
+						entries.push(...result.entries);
+						errors.push(...result.errors);
+					}
+
+					filesProcessed++;
+				} catch (err) {
+					errors.push({
+						filePath,
+						error: `Failed to read file: ${err instanceof Error ? err.message : String(err)}`,
+					});
+					filesSkipped++;
+				}
+			}
+		} catch (err) {
+			log.warn(`Could not scan ${projectsDir}: ${err}`);
+		}
+	}
+
+	return {
+		entries,
+		filesProcessed,
+		filesSkipped,
+		entriesFound: entries.length,
+		errors,
+		configDirsUsed: configDirs,
+	};
+}
+
+/**
+ * Get file metadata for tracking
+ */
+export async function getFileMetadata(
+	filePath: string,
+): Promise<{ modifiedAt: number; size: number } | null> {
+	try {
+		const fileStat = await stat(filePath);
+		return {
+			modifiedAt: fileStat.mtimeMs,
+			size: fileStat.size,
+		};
+	} catch {
+		return null;
+	}
+}

--- a/packages/claude-logs/src/service.ts
+++ b/packages/claude-logs/src/service.ts
@@ -1,0 +1,254 @@
+import { Logger } from "@better-ccflare/logger";
+import { scanAllJSONLFiles, scanModifiedFiles, getFileMetadata } from "./scanner";
+import { ClaudeLogWatcher } from "./watcher";
+import type {
+	ClaudeLogsServiceOptions,
+	ProcessedFile,
+	ScanResult,
+} from "./types";
+
+const log = new Logger("ClaudeLogsService");
+
+// Default scan interval: 1 minute
+const DEFAULT_SCAN_INTERVAL_MS = 60000;
+
+/**
+ * Repository interface for Claude logs database operations
+ */
+export interface ClaudeLogsRepository {
+	saveEntries(entries: import("./types").ParsedLogEntry[]): Promise<void>;
+	getProcessedFiles(): Promise<Map<string, ProcessedFile>>;
+	markFileProcessed(file: ProcessedFile): Promise<void>;
+	deleteEntriesFromFile(filePath: string): Promise<void>;
+}
+
+/**
+ * Main service for managing Claude log file scanning and watching
+ */
+export class ClaudeLogsService {
+	private repository: ClaudeLogsRepository;
+	private watcher: ClaudeLogWatcher;
+	private scanIntervalTimer: Timer | null = null;
+	private processedFiles: Map<string, ProcessedFile> = new Map();
+	private initialized = false;
+	private options: Required<ClaudeLogsServiceOptions>;
+
+	constructor(repository: ClaudeLogsRepository) {
+		this.repository = repository;
+		this.watcher = new ClaudeLogWatcher();
+		this.options = {
+			watchEnabled: false,
+			scanOnStartup: true,
+			scanIntervalMs: DEFAULT_SCAN_INTERVAL_MS,
+		};
+
+		// Set up watcher callback
+		this.watcher.onFileChange(async (event) => {
+			log.info(`File ${event.type}: ${event.filePath}`);
+			await this.processModifiedFile(event.filePath);
+		});
+	}
+
+	/**
+	 * Initialize the service
+	 */
+	async initialize(options?: ClaudeLogsServiceOptions): Promise<void> {
+		if (this.initialized) {
+			log.warn("Service already initialized");
+			return;
+		}
+
+		// Merge options
+		this.options = {
+			...this.options,
+			...options,
+		};
+
+		log.info("Initializing Claude logs service", this.options);
+
+		// Load processed files from database
+		this.processedFiles = await this.repository.getProcessedFiles();
+		log.info(`Loaded ${this.processedFiles.size} processed file records`);
+
+		// Scan on startup if enabled
+		if (this.options.scanOnStartup) {
+			await this.scanAndImport();
+		}
+
+		// Start watching if enabled
+		if (this.options.watchEnabled) {
+			this.startWatching();
+		}
+
+		// Start periodic scanning if interval is set
+		if (this.options.scanIntervalMs > 0) {
+			this.startPeriodicScan();
+		}
+
+		this.initialized = true;
+	}
+
+	/**
+	 * Perform a full scan of all JSONL files
+	 */
+	async scanAndImport(): Promise<ScanResult> {
+		log.info("Starting full scan of Claude log files");
+
+		const result = await scanAllJSONLFiles();
+
+		if (result.entries.length > 0) {
+			await this.repository.saveEntries(result.entries);
+			log.info(`Saved ${result.entries.length} entries to database`);
+		}
+
+		// Update processed files tracking
+		await this.updateProcessedFilesFromScan(result);
+
+		return result;
+	}
+
+	/**
+	 * Perform an incremental scan of modified files only
+	 */
+	async incrementalScan(): Promise<ScanResult> {
+		log.debug("Starting incremental scan");
+
+		const result = await scanModifiedFiles(this.processedFiles);
+
+		if (result.entries.length > 0) {
+			await this.repository.saveEntries(result.entries);
+			log.info(`Saved ${result.entries.length} new entries to database`);
+		}
+
+		// Update processed files tracking
+		await this.updateProcessedFilesFromScan(result);
+
+		return result;
+	}
+
+	/**
+	 * Start file watching
+	 */
+	startWatching(): void {
+		if (this.watcher.watching) {
+			return;
+		}
+
+		this.watcher.start();
+		log.info("File watching started");
+	}
+
+	/**
+	 * Stop file watching
+	 */
+	stopWatching(): void {
+		this.watcher.stop();
+		log.info("File watching stopped");
+	}
+
+	/**
+	 * Check if the service is watching for changes
+	 */
+	get isWatching(): boolean {
+		return this.watcher.watching;
+	}
+
+	/**
+	 * Dispose of the service
+	 */
+	dispose(): void {
+		// Stop watching
+		this.watcher.stop();
+
+		// Stop periodic scanning
+		if (this.scanIntervalTimer) {
+			clearInterval(this.scanIntervalTimer);
+			this.scanIntervalTimer = null;
+		}
+
+		this.initialized = false;
+		log.info("Claude logs service disposed");
+	}
+
+	/**
+	 * Start periodic scanning
+	 */
+	private startPeriodicScan(): void {
+		if (this.scanIntervalTimer) {
+			return;
+		}
+
+		this.scanIntervalTimer = setInterval(async () => {
+			try {
+				await this.incrementalScan();
+			} catch (err) {
+				log.error("Error during periodic scan:", err);
+			}
+		}, this.options.scanIntervalMs);
+
+		// Unref the timer so it doesn't keep the process alive
+		if ("unref" in this.scanIntervalTimer) {
+			(this.scanIntervalTimer as NodeJS.Timeout).unref();
+		}
+
+		log.info(
+			`Periodic scanning started (interval: ${this.options.scanIntervalMs}ms)`,
+		);
+	}
+
+	/**
+	 * Process a single modified file
+	 */
+	private async processModifiedFile(filePath: string): Promise<void> {
+		const metadata = await getFileMetadata(filePath);
+
+		if (!metadata) {
+			// File was deleted, remove its entries
+			await this.repository.deleteEntriesFromFile(filePath);
+			this.processedFiles.delete(filePath);
+			return;
+		}
+
+		// Trigger incremental scan for this file
+		const tempProcessed = new Map(this.processedFiles);
+		tempProcessed.delete(filePath); // Force re-scan of this file
+
+		const result = await scanModifiedFiles(tempProcessed);
+
+		if (result.entries.length > 0) {
+			await this.repository.saveEntries(result.entries);
+		}
+
+		await this.updateProcessedFilesFromScan(result);
+	}
+
+	/**
+	 * Update processed files tracking from scan result
+	 */
+	private async updateProcessedFilesFromScan(result: ScanResult): Promise<void> {
+		// Group entries by file to get line counts
+		const fileEntries = new Map<string, number>();
+		for (const entry of result.entries) {
+			const count = fileEntries.get(entry.filePath) || 0;
+			fileEntries.set(entry.filePath, count + 1);
+		}
+
+		// Update tracking for processed files
+		for (const [filePath, entryCount] of fileEntries) {
+			const metadata = await getFileMetadata(filePath);
+			if (metadata) {
+				const existing = this.processedFiles.get(filePath);
+				const processedFile: ProcessedFile = {
+					filePath,
+					lastModifiedAt: metadata.modifiedAt,
+					lastSize: metadata.size,
+					lastLineCount: (existing?.lastLineCount || 0) + entryCount,
+					processedAt: Date.now(),
+				};
+
+				this.processedFiles.set(filePath, processedFile);
+				await this.repository.markFileProcessed(processedFile);
+			}
+		}
+	}
+}

--- a/packages/claude-logs/src/types.ts
+++ b/packages/claude-logs/src/types.ts
@@ -1,0 +1,98 @@
+/**
+ * Raw JSONL log entry structure from Claude Code log files
+ */
+export interface RawLogEntry {
+	uuid: string;
+	sessionId: string;
+	timestamp: string; // ISO-8601
+	message?: {
+		role?: "user" | "assistant";
+		model?: string;
+		usage?: {
+			input_tokens?: number;
+			output_tokens?: number;
+			cache_creation_input_tokens?: number;
+			cache_read_input_tokens?: number;
+		};
+	};
+	costUSD?: number;
+	gitBranch?: string;
+	cwd?: string;
+}
+
+/**
+ * Parsed and normalized log entry ready for database storage
+ */
+export interface ParsedLogEntry {
+	uuid: string;
+	sessionId: string;
+	projectPath: string;
+	timestamp: number; // Unix timestamp ms
+	role: string;
+	model: string | null;
+	inputTokens: number;
+	outputTokens: number;
+	cacheCreationInputTokens: number;
+	cacheReadInputTokens: number;
+	totalTokens: number;
+	costUsd: number;
+	gitBranch: string | null;
+	cwd: string | null;
+	filePath: string;
+	fileModifiedAt: number;
+}
+
+/**
+ * File metadata for incremental processing
+ */
+export interface ProcessedFile {
+	filePath: string;
+	lastModifiedAt: number;
+	lastSize: number;
+	lastLineCount: number;
+	processedAt: number;
+}
+
+/**
+ * Result from scanning JSONL files
+ */
+export interface ScanResult {
+	entries: ParsedLogEntry[];
+	filesProcessed: number;
+	filesSkipped: number;
+	entriesFound: number;
+	errors: ScanError[];
+	configDirsUsed: string[];
+}
+
+/**
+ * Error during scanning
+ */
+export interface ScanError {
+	filePath: string;
+	line?: number;
+	error: string;
+}
+
+/**
+ * Options for the ClaudeLogsService
+ */
+export interface ClaudeLogsServiceOptions {
+	watchEnabled?: boolean;
+	scanOnStartup?: boolean;
+	scanIntervalMs?: number;
+}
+
+/**
+ * File watcher event types
+ */
+export type FileWatchEvent = "created" | "modified" | "deleted";
+
+/**
+ * File watcher event data
+ */
+export interface FileWatchEventData {
+	type: FileWatchEvent;
+	filePath: string;
+	timestamp: number;
+}

--- a/packages/claude-logs/src/watcher.ts
+++ b/packages/claude-logs/src/watcher.ts
@@ -1,0 +1,157 @@
+import { watch, type FSWatcher } from "node:fs";
+import { Logger } from "@better-ccflare/logger";
+import { getClaudeConfigDirs, getProjectsDir } from "./paths";
+import type { FileWatchEvent, FileWatchEventData } from "./types";
+
+const log = new Logger("ClaudeLogWatcher");
+
+// Debounce delay for rapid file events
+const DEBOUNCE_MS = 500;
+
+type WatcherCallback = (event: FileWatchEventData) => void;
+
+/**
+ * File watcher for Claude log directories
+ *
+ * Watches for .jsonl file changes in Claude config directories
+ * and emits debounced events.
+ */
+export class ClaudeLogWatcher {
+	private watchers: FSWatcher[] = [];
+	private callbacks: WatcherCallback[] = [];
+	private debounceTimers: Map<string, Timer> = new Map();
+	private isWatching = false;
+
+	/**
+	 * Add a callback for file events
+	 */
+	onFileChange(callback: WatcherCallback): void {
+		this.callbacks.push(callback);
+	}
+
+	/**
+	 * Start watching Claude config directories
+	 */
+	start(): void {
+		if (this.isWatching) {
+			return;
+		}
+
+		const configDirs = getClaudeConfigDirs();
+
+		if (configDirs.length === 0) {
+			log.warn("No Claude config directories found to watch");
+			return;
+		}
+
+		for (const configDir of configDirs) {
+			const projectsDir = getProjectsDir(configDir);
+
+			try {
+				const watcher = watch(
+					projectsDir,
+					{ recursive: true },
+					(eventType, filename) => {
+						if (!filename || !filename.endsWith(".jsonl")) {
+							return;
+						}
+
+						const filePath = `${projectsDir}/${filename}`;
+						this.handleFileEvent(eventType as "rename" | "change", filePath);
+					},
+				);
+
+				watcher.on("error", (err) => {
+					log.error(`Watcher error for ${projectsDir}:`, err);
+				});
+
+				this.watchers.push(watcher);
+				log.info(`Watching for changes in ${projectsDir}`);
+			} catch (err) {
+				log.warn(`Could not watch ${projectsDir}: ${err}`);
+			}
+		}
+
+		this.isWatching = true;
+	}
+
+	/**
+	 * Stop watching all directories
+	 */
+	stop(): void {
+		for (const watcher of this.watchers) {
+			watcher.close();
+		}
+		this.watchers = [];
+
+		// Clear all debounce timers
+		for (const timer of this.debounceTimers.values()) {
+			clearTimeout(timer);
+		}
+		this.debounceTimers.clear();
+
+		this.isWatching = false;
+		log.info("Stopped watching Claude log directories");
+	}
+
+	/**
+	 * Check if currently watching
+	 */
+	get watching(): boolean {
+		return this.isWatching;
+	}
+
+	/**
+	 * Handle raw file events with debouncing
+	 */
+	private handleFileEvent(
+		eventType: "rename" | "change",
+		filePath: string,
+	): void {
+		// Clear existing timer for this file
+		const existingTimer = this.debounceTimers.get(filePath);
+		if (existingTimer) {
+			clearTimeout(existingTimer);
+		}
+
+		// Set new debounced timer
+		const timer = setTimeout(() => {
+			this.debounceTimers.delete(filePath);
+			this.emitEvent(eventType, filePath);
+		}, DEBOUNCE_MS);
+
+		this.debounceTimers.set(filePath, timer);
+	}
+
+	/**
+	 * Emit debounced event to all callbacks
+	 */
+	private emitEvent(eventType: "rename" | "change", filePath: string): void {
+		// Map fs.watch event types to our event types
+		let type: FileWatchEvent;
+
+		if (eventType === "rename") {
+			// "rename" can mean created or deleted - we'd need to check if file exists
+			// For simplicity, treat as modified and let the scanner handle it
+			type = "modified";
+		} else {
+			type = "modified";
+		}
+
+		const eventData: FileWatchEventData = {
+			type,
+			filePath,
+			timestamp: Date.now(),
+		};
+
+		log.debug(`File ${type}: ${filePath}`);
+
+		for (const callback of this.callbacks) {
+			try {
+				callback(eventData);
+			} catch (err) {
+				log.error("Error in watcher callback:", err);
+			}
+		}
+	}
+}

--- a/packages/claude-logs/tsconfig.json
+++ b/packages/claude-logs/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"module": "esnext",
+		"moduleResolution": "bundler"
+	},
+	"include": ["src/**/*"]
+}

--- a/packages/database/src/database-operations.ts
+++ b/packages/database/src/database-operations.ts
@@ -8,6 +8,7 @@ import { ensureSchema, runMigrations } from "./migrations";
 import { resolveDbPath } from "./paths";
 import { AccountRepository } from "./repositories/account.repository";
 import { AgentPreferenceRepository } from "./repositories/agent-preference.repository";
+import { ClaudeLogsRepository } from "./repositories/claude-logs.repository";
 import { OAuthRepository } from "./repositories/oauth.repository";
 import {
 	type RequestData,
@@ -130,6 +131,7 @@ export class DatabaseOperations implements StrategyStore, Disposable {
 	private strategy: StrategyRepository;
 	private stats: StatsRepository;
 	private agentPreferences: AgentPreferenceRepository;
+	private claudeLogs: ClaudeLogsRepository;
 
 	constructor(
 		dbPath?: string,
@@ -177,6 +179,7 @@ export class DatabaseOperations implements StrategyStore, Disposable {
 		this.strategy = new StrategyRepository(this.db);
 		this.stats = new StatsRepository(this.db);
 		this.agentPreferences = new AgentPreferenceRepository(this.db);
+		this.claudeLogs = new ClaudeLogsRepository(this.db);
 	}
 
 	setRuntimeConfig(runtime: RuntimeConfig): void {
@@ -611,5 +614,12 @@ export class DatabaseOperations implements StrategyStore, Disposable {
 	 */
 	getStatsRepository(): StatsRepository {
 		return this.stats;
+	}
+
+	/**
+	 * Get the Claude logs repository for usage analysis
+	 */
+	getClaudeLogsRepository(): ClaudeLogsRepository {
+		return this.claudeLogs;
 	}
 }

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -17,6 +17,7 @@ export { analyzeIndexUsage } from "./performance-indexes";
 
 // Re-export repository types
 export type { StatsRepository } from "./repositories/stats.repository";
+export { ClaudeLogsRepository } from "./repositories/claude-logs.repository";
 
 // Re-export retry utilities for external use (from your improvements)
 export { withDatabaseRetry, withDatabaseRetrySync } from "./retry";

--- a/packages/database/src/repositories/claude-logs.repository.ts
+++ b/packages/database/src/repositories/claude-logs.repository.ts
@@ -1,0 +1,391 @@
+import type { Database } from "bun:sqlite";
+import type {
+	ClaudeLogEntryRow,
+	ClaudeProcessedFileRow,
+	DailyUsage,
+	MonthlyUsage,
+	SessionUsage,
+	BillingBlockUsage,
+	ProjectSummary,
+} from "@better-ccflare/types";
+import { BaseRepository } from "./base.repository";
+
+/**
+ * Parsed log entry from the claude-logs package
+ */
+export interface ParsedLogEntry {
+	uuid: string;
+	sessionId: string;
+	projectPath: string;
+	timestamp: number;
+	role: string;
+	model: string | null;
+	inputTokens: number;
+	outputTokens: number;
+	cacheCreationInputTokens: number;
+	cacheReadInputTokens: number;
+	totalTokens: number;
+	costUsd: number;
+	gitBranch: string | null;
+	cwd: string | null;
+	filePath: string;
+	fileModifiedAt: number;
+}
+
+/**
+ * Processed file tracking info
+ */
+export interface ProcessedFile {
+	filePath: string;
+	lastModifiedAt: number;
+	lastSize: number;
+	lastLineCount: number;
+	processedAt: number;
+}
+
+/**
+ * Repository for Claude log entries database operations
+ */
+export class ClaudeLogsRepository extends BaseRepository<ClaudeLogEntryRow> {
+	constructor(db: Database) {
+		super(db);
+	}
+
+	/**
+	 * Save a single log entry (upsert)
+	 */
+	saveEntry(entry: ParsedLogEntry): void {
+		this.run(
+			`INSERT OR REPLACE INTO claude_log_entries (
+				uuid, session_id, project_path, timestamp, role, model,
+				input_tokens, output_tokens, cache_creation_input_tokens,
+				cache_read_input_tokens, total_tokens, cost_usd,
+				git_branch, cwd, file_path, file_modified_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			[
+				entry.uuid,
+				entry.sessionId,
+				entry.projectPath,
+				entry.timestamp,
+				entry.role,
+				entry.model,
+				entry.inputTokens,
+				entry.outputTokens,
+				entry.cacheCreationInputTokens,
+				entry.cacheReadInputTokens,
+				entry.totalTokens,
+				entry.costUsd,
+				entry.gitBranch,
+				entry.cwd,
+				entry.filePath,
+				entry.fileModifiedAt,
+			],
+		);
+	}
+
+	/**
+	 * Save multiple log entries in a transaction
+	 */
+	async saveEntries(entries: ParsedLogEntry[]): Promise<void> {
+		if (entries.length === 0) return;
+
+		const insertStmt = this.db.prepare(
+			`INSERT OR REPLACE INTO claude_log_entries (
+				uuid, session_id, project_path, timestamp, role, model,
+				input_tokens, output_tokens, cache_creation_input_tokens,
+				cache_read_input_tokens, total_tokens, cost_usd,
+				git_branch, cwd, file_path, file_modified_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		);
+
+		const transaction = this.db.transaction((entries: ParsedLogEntry[]) => {
+			for (const entry of entries) {
+				insertStmt.run(
+					entry.uuid,
+					entry.sessionId,
+					entry.projectPath,
+					entry.timestamp,
+					entry.role,
+					entry.model,
+					entry.inputTokens,
+					entry.outputTokens,
+					entry.cacheCreationInputTokens,
+					entry.cacheReadInputTokens,
+					entry.totalTokens,
+					entry.costUsd,
+					entry.gitBranch,
+					entry.cwd,
+					entry.filePath,
+					entry.fileModifiedAt,
+				);
+			}
+		});
+
+		transaction(entries);
+	}
+
+	/**
+	 * Get daily usage aggregation
+	 */
+	getDailyUsage(
+		startDate?: string,
+		endDate?: string,
+		project?: string,
+	): DailyUsage[] {
+		let sql = `
+			SELECT
+				date(timestamp / 1000, 'unixepoch', 'localtime') as date,
+				SUM(input_tokens) as inputTokens,
+				SUM(output_tokens) as outputTokens,
+				SUM(cache_creation_input_tokens) as cacheCreationInputTokens,
+				SUM(cache_read_input_tokens) as cacheReadInputTokens,
+				SUM(total_tokens) as totalTokens,
+				SUM(cost_usd) as costUsd,
+				COUNT(*) as requestCount,
+				COUNT(DISTINCT session_id) as sessionCount
+			FROM claude_log_entries
+			WHERE 1=1
+		`;
+		const params: (string | number)[] = [];
+
+		if (startDate) {
+			sql += ` AND date(timestamp / 1000, 'unixepoch', 'localtime') >= ?`;
+			params.push(startDate);
+		}
+		if (endDate) {
+			sql += ` AND date(timestamp / 1000, 'unixepoch', 'localtime') <= ?`;
+			params.push(endDate);
+		}
+		if (project) {
+			sql += ` AND project_path = ?`;
+			params.push(project);
+		}
+
+		sql += ` GROUP BY date ORDER BY date DESC`;
+
+		return this.query<DailyUsage>(sql, params);
+	}
+
+	/**
+	 * Get monthly usage aggregation
+	 */
+	getMonthlyUsage(startMonth?: string, endMonth?: string): MonthlyUsage[] {
+		let sql = `
+			SELECT
+				strftime('%Y-%m', timestamp / 1000, 'unixepoch', 'localtime') as month,
+				SUM(input_tokens) as inputTokens,
+				SUM(output_tokens) as outputTokens,
+				SUM(cache_creation_input_tokens) as cacheCreationInputTokens,
+				SUM(cache_read_input_tokens) as cacheReadInputTokens,
+				SUM(total_tokens) as totalTokens,
+				SUM(cost_usd) as costUsd,
+				COUNT(*) as requestCount,
+				COUNT(DISTINCT session_id) as sessionCount,
+				COUNT(DISTINCT date(timestamp / 1000, 'unixepoch', 'localtime')) as dayCount
+			FROM claude_log_entries
+			WHERE 1=1
+		`;
+		const params: string[] = [];
+
+		if (startMonth) {
+			sql += ` AND strftime('%Y-%m', timestamp / 1000, 'unixepoch', 'localtime') >= ?`;
+			params.push(startMonth);
+		}
+		if (endMonth) {
+			sql += ` AND strftime('%Y-%m', timestamp / 1000, 'unixepoch', 'localtime') <= ?`;
+			params.push(endMonth);
+		}
+
+		sql += ` GROUP BY month ORDER BY month DESC`;
+
+		return this.query<MonthlyUsage>(sql, params);
+	}
+
+	/**
+	 * Get session-based usage with pagination
+	 */
+	getSessionUsage(
+		limit = 50,
+		offset = 0,
+		project?: string,
+	): { sessions: SessionUsage[]; totalCount: number } {
+		let countSql = `SELECT COUNT(DISTINCT session_id) as count FROM claude_log_entries WHERE 1=1`;
+		let sql = `
+			SELECT
+				session_id as sessionId,
+				project_path as projectPath,
+				MIN(timestamp) as startTime,
+				MAX(timestamp) as endTime,
+				SUM(input_tokens) as inputTokens,
+				SUM(output_tokens) as outputTokens,
+				SUM(cache_creation_input_tokens) as cacheCreationInputTokens,
+				SUM(cache_read_input_tokens) as cacheReadInputTokens,
+				SUM(total_tokens) as totalTokens,
+				SUM(cost_usd) as costUsd,
+				COUNT(*) as requestCount,
+				MAX(model) as model,
+				MAX(git_branch) as gitBranch
+			FROM claude_log_entries
+			WHERE 1=1
+		`;
+		const params: (string | number)[] = [];
+		const countParams: string[] = [];
+
+		if (project) {
+			sql += ` AND project_path = ?`;
+			countSql += ` AND project_path = ?`;
+			params.push(project);
+			countParams.push(project);
+		}
+
+		sql += ` GROUP BY session_id ORDER BY endTime DESC LIMIT ? OFFSET ?`;
+		params.push(limit, offset);
+
+		const sessions = this.query<SessionUsage>(sql, params).map((s) => ({
+			...s,
+			startTime: new Date(s.startTime as unknown as number).toISOString(),
+			endTime: new Date(s.endTime as unknown as number).toISOString(),
+		}));
+
+		const countResult = this.get<{ count: number }>(countSql, countParams);
+		const totalCount = countResult?.count || 0;
+
+		return { sessions, totalCount };
+	}
+
+	/**
+	 * Get 5-hour billing block usage (matches Anthropic's rate limit windows)
+	 */
+	getBillingBlockUsage(
+		startTime?: number,
+		endTime?: number,
+	): BillingBlockUsage[] {
+		// 5 hours in milliseconds
+		const blockSize = 5 * 60 * 60 * 1000;
+
+		let sql = `
+			SELECT
+				(timestamp / ${blockSize}) * ${blockSize} as blockStart,
+				((timestamp / ${blockSize}) + 1) * ${blockSize} as blockEnd,
+				SUM(input_tokens) as inputTokens,
+				SUM(output_tokens) as outputTokens,
+				SUM(cache_creation_input_tokens) as cacheCreationInputTokens,
+				SUM(cache_read_input_tokens) as cacheReadInputTokens,
+				SUM(total_tokens) as totalTokens,
+				SUM(cost_usd) as costUsd,
+				COUNT(*) as requestCount
+			FROM claude_log_entries
+			WHERE 1=1
+		`;
+		const params: number[] = [];
+
+		if (startTime) {
+			sql += ` AND timestamp >= ?`;
+			params.push(startTime);
+		}
+		if (endTime) {
+			sql += ` AND timestamp <= ?`;
+			params.push(endTime);
+		}
+
+		sql += ` GROUP BY blockStart ORDER BY blockStart DESC`;
+
+		return this.query<BillingBlockUsage>(sql, params).map((b) => ({
+			...b,
+			blockStart: new Date(b.blockStart as unknown as number).toISOString(),
+			blockEnd: new Date(b.blockEnd as unknown as number).toISOString(),
+		}));
+	}
+
+	/**
+	 * Get list of unique projects
+	 */
+	getProjects(): ProjectSummary[] {
+		const sql = `
+			SELECT
+				project_path as projectPath,
+				COUNT(DISTINCT session_id) as sessionCount,
+				SUM(total_tokens) as totalTokens,
+				SUM(cost_usd) as costUsd,
+				MAX(timestamp) as lastActivity
+			FROM claude_log_entries
+			GROUP BY project_path
+			ORDER BY lastActivity DESC
+		`;
+
+		return this.query<ProjectSummary>(sql).map((p) => ({
+			...p,
+			lastActivity: new Date(p.lastActivity as unknown as number).toISOString(),
+		}));
+	}
+
+	/**
+	 * Get all processed files for incremental scanning
+	 */
+	async getProcessedFiles(): Promise<Map<string, ProcessedFile>> {
+		const rows = this.query<ClaudeProcessedFileRow>(
+			`SELECT * FROM claude_processed_files`,
+		);
+
+		const map = new Map<string, ProcessedFile>();
+		for (const row of rows) {
+			map.set(row.file_path, {
+				filePath: row.file_path,
+				lastModifiedAt: row.last_modified_at,
+				lastSize: row.last_size,
+				lastLineCount: row.last_line_count,
+				processedAt: row.processed_at,
+			});
+		}
+
+		return map;
+	}
+
+	/**
+	 * Mark a file as processed
+	 */
+	async markFileProcessed(file: ProcessedFile): Promise<void> {
+		this.run(
+			`INSERT OR REPLACE INTO claude_processed_files
+			(file_path, last_modified_at, last_size, last_line_count, processed_at)
+			VALUES (?, ?, ?, ?, ?)`,
+			[
+				file.filePath,
+				file.lastModifiedAt,
+				file.lastSize,
+				file.lastLineCount,
+				file.processedAt,
+			],
+		);
+	}
+
+	/**
+	 * Delete all entries from a specific file (for re-processing)
+	 */
+	async deleteEntriesFromFile(filePath: string): Promise<void> {
+		this.run(`DELETE FROM claude_log_entries WHERE file_path = ?`, [filePath]);
+		this.run(`DELETE FROM claude_processed_files WHERE file_path = ?`, [
+			filePath,
+		]);
+	}
+
+	/**
+	 * Get total entry count
+	 */
+	getTotalEntryCount(): number {
+		const result = this.get<{ count: number }>(
+			`SELECT COUNT(*) as count FROM claude_log_entries`,
+		);
+		return result?.count || 0;
+	}
+
+	/**
+	 * Get total cost across all entries
+	 */
+	getTotalCost(): number {
+		const result = this.get<{ total: number }>(
+			`SELECT SUM(cost_usd) as total FROM claude_log_entries`,
+		);
+		return result?.total || 0;
+	}
+}

--- a/packages/http-api/package.json
+++ b/packages/http-api/package.json
@@ -11,6 +11,7 @@
 	},
 	"dependencies": {
 		"@better-ccflare/agents": "workspace:*",
+		"@better-ccflare/claude-logs": "workspace:*",
 		"@better-ccflare/core": "workspace:*",
 		"@better-ccflare/database": "workspace:*",
 		"@better-ccflare/config": "workspace:*",

--- a/packages/http-api/src/handlers/usage.ts
+++ b/packages/http-api/src/handlers/usage.ts
@@ -1,0 +1,200 @@
+import type { ClaudeLogsRepository } from "@better-ccflare/database";
+import { jsonResponse } from "@better-ccflare/http-common";
+import type { UsageApiResponse, ScanResultResponse } from "@better-ccflare/types";
+import type { ClaudeLogsService } from "@better-ccflare/claude-logs";
+
+/**
+ * Create a handler for daily usage aggregation
+ * GET /api/usage/daily?startDate=YYYY-MM-DD&endDate=YYYY-MM-DD&project=path
+ */
+export function createDailyUsageHandler(claudeLogsRepo: ClaudeLogsRepository) {
+	return (url: URL): Response => {
+		const startDate = url.searchParams.get("startDate") || undefined;
+		const endDate = url.searchParams.get("endDate") || undefined;
+		const project = url.searchParams.get("project") || undefined;
+
+		const data = claudeLogsRepo.getDailyUsage(startDate, endDate, project);
+
+		const response: UsageApiResponse<typeof data> = {
+			success: true,
+			data,
+			meta: {
+				generatedAt: new Date().toISOString(),
+				configDirs: [],
+			},
+		};
+
+		return jsonResponse(response);
+	};
+}
+
+/**
+ * Create a handler for monthly usage aggregation
+ * GET /api/usage/monthly?startMonth=YYYY-MM&endMonth=YYYY-MM
+ */
+export function createMonthlyUsageHandler(claudeLogsRepo: ClaudeLogsRepository) {
+	return (url: URL): Response => {
+		const startMonth = url.searchParams.get("startMonth") || undefined;
+		const endMonth = url.searchParams.get("endMonth") || undefined;
+
+		const data = claudeLogsRepo.getMonthlyUsage(startMonth, endMonth);
+
+		const response: UsageApiResponse<typeof data> = {
+			success: true,
+			data,
+			meta: {
+				generatedAt: new Date().toISOString(),
+				configDirs: [],
+			},
+		};
+
+		return jsonResponse(response);
+	};
+}
+
+/**
+ * Create a handler for session-based usage
+ * GET /api/usage/sessions?limit=50&offset=0&project=path
+ */
+export function createSessionUsageHandler(claudeLogsRepo: ClaudeLogsRepository) {
+	return (url: URL): Response => {
+		const limit = Number.parseInt(url.searchParams.get("limit") || "50", 10);
+		const offset = Number.parseInt(url.searchParams.get("offset") || "0", 10);
+		const project = url.searchParams.get("project") || undefined;
+
+		const { sessions, totalCount } = claudeLogsRepo.getSessionUsage(
+			limit,
+			offset,
+			project,
+		);
+
+		const response: UsageApiResponse<typeof sessions> = {
+			success: true,
+			data: sessions,
+			pagination: {
+				page: Math.floor(offset / limit) + 1,
+				pageSize: limit,
+				totalCount,
+				totalPages: Math.ceil(totalCount / limit),
+			},
+			meta: {
+				generatedAt: new Date().toISOString(),
+				configDirs: [],
+			},
+		};
+
+		return jsonResponse(response);
+	};
+}
+
+/**
+ * Create a handler for 5-hour billing block usage
+ * GET /api/usage/blocks?startTime=timestamp&endTime=timestamp
+ */
+export function createBillingBlocksHandler(claudeLogsRepo: ClaudeLogsRepository) {
+	return (url: URL): Response => {
+		const startTimeParam = url.searchParams.get("startTime");
+		const endTimeParam = url.searchParams.get("endTime");
+
+		const startTime = startTimeParam
+			? Number.parseInt(startTimeParam, 10)
+			: undefined;
+		const endTime = endTimeParam
+			? Number.parseInt(endTimeParam, 10)
+			: undefined;
+
+		const data = claudeLogsRepo.getBillingBlockUsage(startTime, endTime);
+
+		const response: UsageApiResponse<typeof data> = {
+			success: true,
+			data,
+			meta: {
+				generatedAt: new Date().toISOString(),
+				configDirs: [],
+			},
+		};
+
+		return jsonResponse(response);
+	};
+}
+
+/**
+ * Create a handler for listing projects
+ * GET /api/usage/projects
+ */
+export function createProjectsListHandler(claudeLogsRepo: ClaudeLogsRepository) {
+	return (): Response => {
+		const data = claudeLogsRepo.getProjects();
+
+		const response: UsageApiResponse<typeof data> = {
+			success: true,
+			data,
+			meta: {
+				generatedAt: new Date().toISOString(),
+				configDirs: [],
+			},
+		};
+
+		return jsonResponse(response);
+	};
+}
+
+/**
+ * Create a handler for triggering a manual scan
+ * POST /api/usage/scan
+ */
+export function createScanHandler(claudeLogsService: ClaudeLogsService) {
+	return async (): Promise<Response> => {
+		const result = await claudeLogsService.scanAndImport();
+
+		const response: UsageApiResponse<ScanResultResponse> = {
+			success: true,
+			data: {
+				filesProcessed: result.filesProcessed,
+				filesSkipped: result.filesSkipped,
+				entriesFound: result.entriesFound,
+				errors: result.errors,
+				configDirsUsed: result.configDirsUsed,
+			},
+			meta: {
+				generatedAt: new Date().toISOString(),
+				configDirs: result.configDirsUsed,
+			},
+		};
+
+		return jsonResponse(response);
+	};
+}
+
+/**
+ * Create a handler for getting usage summary/overview
+ * GET /api/usage/summary
+ */
+export function createUsageSummaryHandler(claudeLogsRepo: ClaudeLogsRepository) {
+	return (): Response => {
+		const totalEntries = claudeLogsRepo.getTotalEntryCount();
+		const totalCost = claudeLogsRepo.getTotalCost();
+		const projects = claudeLogsRepo.getProjects();
+
+		const response: UsageApiResponse<{
+			totalEntries: number;
+			totalCost: number;
+			projectCount: number;
+			projects: typeof projects;
+		}> = {
+			success: true,
+			data: {
+				totalEntries,
+				totalCost,
+				projectCount: projects.length,
+				projects,
+			},
+			meta: {
+				generatedAt: new Date().toISOString(),
+				configDirs: [],
+			},
+		};
+
+		return jsonResponse(response);
+	};
+}

--- a/packages/types/src/claude-usage.ts
+++ b/packages/types/src/claude-usage.ts
@@ -1,0 +1,145 @@
+/**
+ * Types for Claude Code usage analysis API responses
+ */
+
+/**
+ * Daily usage aggregation
+ */
+export interface DailyUsage {
+	date: string; // YYYY-MM-DD
+	inputTokens: number;
+	outputTokens: number;
+	cacheCreationInputTokens: number;
+	cacheReadInputTokens: number;
+	totalTokens: number;
+	costUsd: number;
+	requestCount: number;
+	sessionCount: number;
+}
+
+/**
+ * Monthly usage aggregation
+ */
+export interface MonthlyUsage {
+	month: string; // YYYY-MM
+	inputTokens: number;
+	outputTokens: number;
+	cacheCreationInputTokens: number;
+	cacheReadInputTokens: number;
+	totalTokens: number;
+	costUsd: number;
+	requestCount: number;
+	sessionCount: number;
+	dayCount: number;
+}
+
+/**
+ * Session-based usage aggregation
+ */
+export interface SessionUsage {
+	sessionId: string;
+	projectPath: string;
+	startTime: string; // ISO timestamp
+	endTime: string; // ISO timestamp
+	inputTokens: number;
+	outputTokens: number;
+	cacheCreationInputTokens: number;
+	cacheReadInputTokens: number;
+	totalTokens: number;
+	costUsd: number;
+	requestCount: number;
+	model: string | null;
+	gitBranch: string | null;
+}
+
+/**
+ * 5-hour billing block usage (matches Anthropic's rate limit windows)
+ */
+export interface BillingBlockUsage {
+	blockStart: string; // ISO timestamp
+	blockEnd: string; // ISO timestamp
+	inputTokens: number;
+	outputTokens: number;
+	cacheCreationInputTokens: number;
+	cacheReadInputTokens: number;
+	totalTokens: number;
+	costUsd: number;
+	requestCount: number;
+}
+
+/**
+ * Project summary for filtering
+ */
+export interface ProjectSummary {
+	projectPath: string;
+	sessionCount: number;
+	totalTokens: number;
+	costUsd: number;
+	lastActivity: string; // ISO timestamp
+}
+
+/**
+ * Generic API response wrapper
+ */
+export interface UsageApiResponse<T> {
+	success: boolean;
+	data: T;
+	pagination?: {
+		page: number;
+		pageSize: number;
+		totalCount: number;
+		totalPages: number;
+	};
+	meta?: {
+		generatedAt: string;
+		configDirs: string[];
+	};
+}
+
+/**
+ * Scan result response
+ */
+export interface ScanResultResponse {
+	filesProcessed: number;
+	filesSkipped: number;
+	entriesFound: number;
+	errors: Array<{
+		filePath: string;
+		line?: number;
+		error: string;
+	}>;
+	configDirsUsed: string[];
+}
+
+/**
+ * Database row types for Claude log entries
+ */
+export interface ClaudeLogEntryRow {
+	uuid: string;
+	session_id: string;
+	project_path: string;
+	timestamp: number;
+	role: string;
+	model: string | null;
+	input_tokens: number;
+	output_tokens: number;
+	cache_creation_input_tokens: number;
+	cache_read_input_tokens: number;
+	total_tokens: number;
+	cost_usd: number;
+	git_branch: string | null;
+	cwd: string | null;
+	file_path: string;
+	file_modified_at: number;
+}
+
+/**
+ * Database row for processed files tracking
+ */
+export interface ClaudeProcessedFileRow {
+	file_path: string;
+	last_modified_at: number;
+	last_size: number;
+	last_line_count: number;
+	processed_at: number;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -4,6 +4,7 @@ export * from "./agent";
 export * from "./agent-constants";
 // Keep existing exports for backward compatibility
 export * from "./api";
+export * from "./claude-usage";
 export * from "./constants";
 export * from "./context";
 export * from "./conversation";


### PR DESCRIPTION
## Summary

- Add capability to parse Claude Code's local JSONL log files for historical usage analysis
- Enable tracking of token usage, costs, and sessions from local Claude Code installations
- Provide Docker volume mounting support for containerized deployments

## Added

- New `@better-ccflare/claude-logs` package with:
  - JSONL parser with graceful error handling
  - Directory scanner (legacy + XDG paths)
  - File watcher with debouncing
  - ClaudeLogsService for orchestration
- Database schema (`claude_log_entries`, `claude_processed_files`)
- ClaudeLogsRepository with aggregation queries
- HTTP API endpoints:
  - `GET /api/usage/daily` - Daily aggregated usage
  - `GET /api/usage/monthly` - Monthly aggregated usage
  - `GET /api/usage/sessions` - Session-based usage
  - `GET /api/usage/blocks` - 5-hour billing block usage
  - `GET /api/usage/projects` - List of projects
  - `GET /api/usage/summary` - Overall summary
  - `POST /api/usage/scan` - Manual scan trigger
- Configuration options via environment variables
- Docker documentation for volume mounting

## Changed

- Server initialization optionally starts ClaudeLogsService
- APIRouter accepts optional claudeLogsService
- Database operations expose ClaudeLogsRepository

## Test Plan

- [ ] Verify JSONL parsing with sample Claude Code log files
- [ ] Test API endpoints return correct aggregated data
- [ ] Confirm Docker volume mounting works as documented
- [ ] Validate incremental scanning only processes new/modified files

Closes #1
Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)